### PR TITLE
Add additional tags to instances being launched

### DIFF
--- a/terraform-aws/client.tf
+++ b/terraform-aws/client.tf
@@ -38,6 +38,31 @@ resource "aws_launch_configuration" "client" {
   }
 }
 
+locals {
+  client_node_tags = [
+    {
+      key                 = "Name"
+      value               = "elasticsearch-${var.es_cluster}-client-node"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Environment"
+      value               = "${var.environment}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Cluster"
+      value               = "${var.environment}-${var.es_cluster}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Role"
+      value               = "client"
+      propagate_at_launch = true
+    },
+  ]
+}
+
 resource "aws_autoscaling_group" "client_nodes" {
   name = "elasticsearch-${var.es_cluster}-client-nodes"
   max_size = "${var.clients_count}"
@@ -52,29 +77,7 @@ resource "aws_autoscaling_group" "client_nodes" {
 
   vpc_zone_identifier = ["${var.vpc_subnets}"]
 
-  tag {
-    key                 = "Name"
-    value               = "${format("%s-client-node", var.es_cluster)}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Environment"
-    value = "${var.environment}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Cluster"
-    value = "${var.environment}-${var.es_cluster}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Role"
-    value = "client"
-    propagate_at_launch = true
-  }
+  tags = ["${concat(local.tags, local.client_node_tags)}"]
 
   lifecycle {
     create_before_destroy = true

--- a/terraform-aws/datas.tf
+++ b/terraform-aws/datas.tf
@@ -46,6 +46,31 @@ resource "aws_launch_configuration" "data" {
   }
 }
 
+locals {
+  data_node_tags = [
+    {
+      key                 = "Name"
+      value               = "${format("%s-data-node", var.es_cluster)}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Environment"
+      value               = "${var.environment}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Cluster"
+      value               = "${var.environment}-${var.es_cluster}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Role"
+      value               = "data"
+      propagate_at_launch = true
+    },
+  ]
+}
+
 resource "aws_autoscaling_group" "data_nodes" {
   name = "elasticsearch-${var.es_cluster}-data-nodes"
   max_size = "${var.datas_count}"
@@ -59,29 +84,7 @@ resource "aws_autoscaling_group" "data_nodes" {
 
   depends_on = ["aws_autoscaling_group.master_nodes"]
 
-  tag {
-    key                 = "Name"
-    value               = "${format("%s-data-node", var.es_cluster)}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Environment"
-    value = "${var.environment}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Cluster"
-    value = "${var.environment}-${var.es_cluster}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Role"
-    value = "data"
-    propagate_at_launch = true
-  }
+  tags = ["${concat(local.tags, local.data_node_tags)}"]
 
   lifecycle {
     create_before_destroy = true

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -13,10 +13,7 @@ resource "aws_security_group" "elasticsearch_security_group" {
   description = "Elasticsearch ports with ssh"
   vpc_id = "${var.vpc_id}"
 
-  tags {
-    Name = "${var.es_cluster}-elasticsearch"
-    cluster = "${var.es_cluster}"
-  }
+  tags = "${merge(var.tags, map("Name", format("%s-elasticsearch", var.es_cluster), "cluster", var.es_cluster))}"
 
   # ssh access from everywhere
   ingress {
@@ -55,10 +52,7 @@ resource "aws_security_group" "elasticsearch_clients_security_group" {
   description = "Kibana HTTP access from outside"
   vpc_id = "${var.vpc_id}"
 
-  tags {
-    Name = "${var.es_cluster}-kibana"
-    cluster = "${var.es_cluster}"
-  }
+  tags = "${merge(var.tags, map("Name", format("%s-kibana", var.es_cluster), "cluster", var.es_cluster))}"
 
   # allow HTTP access to client nodes via port 8080 - better to disable, and either way always password protect!
   ingress {
@@ -109,7 +103,5 @@ resource "aws_elb" "es_client_lb" {
     interval            = 6
   }
 
-  tags {
-    Name = "${format("%s-client-lb", var.es_cluster)}"
-  }
+  tags = "${merge(var.tags, map("Name", format("%s-client-lb", var.es_cluster)))}"
 }

--- a/terraform-aws/masters.tf
+++ b/terraform-aws/masters.tf
@@ -38,6 +38,31 @@ resource "aws_launch_configuration" "master" {
   }
 }
 
+locals {
+  master_node_tags = [
+    {
+      key                 = "Name"
+      value               = "${format("%s-master-node", var.es_cluster)}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Environment"
+      value               = "${var.environment}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Cluster"
+      value               = "${var.environment}-${var.es_cluster}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Role"
+      value               = "master"
+      propagate_at_launch = true
+    },
+  ]
+}
+
 resource "aws_autoscaling_group" "master_nodes" {
   name = "elasticsearch-${var.es_cluster}-master-nodes"
   max_size = "${var.masters_count}"
@@ -49,29 +74,7 @@ resource "aws_autoscaling_group" "master_nodes" {
 
   vpc_zone_identifier = ["${var.vpc_subnets}"]
 
-  tag {
-    key                 = "Name"
-    value               = "${format("%s-master-node", var.es_cluster)}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Environment"
-    value = "${var.environment}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Cluster"
-    value = "${var.environment}-${var.es_cluster}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Role"
-    value = "master"
-    propagate_at_launch = true
-  }
+  tags = ["${concat(local.tags, local.master_node_tags)}"]
 
   lifecycle {
     create_before_destroy = true

--- a/terraform-aws/tag_adapter.tf
+++ b/terraform-aws/tag_adapter.tf
@@ -1,0 +1,13 @@
+locals {
+  tags = "${null_resource.tag_adapter.*.triggers}"
+}
+
+resource "null_resource" "tag_adapter" {
+  triggers {
+    key                 = "${element(keys(var.tags), count.index)}"
+    value               = "${element(values(var.tags), count.index)}"
+    propagate_at_launch = true
+  }
+
+  count = "${length(var.tags)}"
+}

--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -129,3 +129,8 @@ variable "health_check_type" {
 variable "additional_security_groups" {
   default = ""
 }
+
+variable "tags" {
+  description = "Additional instance tags"
+  default     = {}
+}


### PR DESCRIPTION
At this moment there is a lack of instance tags on elk instances. This may be extremely useful for cost estimation and categorization of ELK cluster.

This PR provides a solution, adding optional `tags` variable, which is exposed to all resources: directly (sg, iam) and idirectly (asg).